### PR TITLE
Change cron schedule to run every 6 hours

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,7 +5,7 @@ on:
   push:
     branches: ['main']
 
-  # Runs every hour
+  # Runs every 6 hours
   schedule:
     - cron: "26 */6 * * *"
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,7 +7,7 @@ on:
 
   # Runs every hour
   schedule:
-    - cron: "0 * * * *"
+    - cron: "26 */6 * * *"
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:


### PR DESCRIPTION
Run once every 6 hours. Which is good enough.

Also try to avoid running exactly on the minute 0. Which is basically the whole world during on that time. Try to think about the planet xd.